### PR TITLE
Implement simple User Management

### DIFF
--- a/snowflake/provider.go
+++ b/snowflake/provider.go
@@ -67,7 +67,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"snowflake_warehouse": resourceWarehouse(),
 			"snowflake_database":  resourceDatabase(),
-			//"snowflake_user":      resourceUser(),
+			"snowflake_user":      resourceUser(),
 			//"snowflake_grant":     resourceGrant(),
 		},
 

--- a/snowflake/resource_user_test.go
+++ b/snowflake/resource_user_test.go
@@ -1,0 +1,28 @@
+package snowflake
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestUserSnowflakeDatabase(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testSnowflakeProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSnowflakeUserConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"snowflake_user", "name", "shoprunner_terraform"),
+					resource.TestCheckResourceAttr("snowflake_user", "user", "tf-test"),
+				),
+			},
+		},
+	})
+}
+
+var testSnowflakeUserConfig = `
+resource "snowflake_user" "shoprunner_terraform" {
+  user = "tf-test"
+}
+`


### PR DESCRIPTION
This allows users to be created, modified, and removed via Terraform.
All SQL queries have been updated to reflect those as specified in the official snowflake documentation:

https://docs.snowflake.net/manuals/sql-reference-commands.html

This allow users to be created, updated, and removed via Terraform using the following resource:

resource "snowflake_user" "tf_test_user" {
  user = "terraform.test"
  host = "mydomain.org"
  plaintext_password = "12345QWERTYqwerty"
  default_role = "READONLY"
}

user - Specifies the username.  This field is mandatory.

host - [OPTIONAL] This specifies the Host/TLD associated with the user.  The default for this is 'localhost'.  This has a direct effect on the Username.

plaintext_password - [OPTIONAL] This specifies the password for the user.  Please ensure that passwords conform to the complexity requirements within Snowflake.

default_role - [OPTIONAL] This specifies the Default Role in which the user is assigned.  By default, this is 'NULL', however, you can specify an existing Role as required.